### PR TITLE
Switch to use VA-API through ffmpeg in decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,6 @@ PLUGIN = vaapidevice
 
 ### Configuration (edit this for your needs)
 
-    # support alsa audio output module
-ALSA ?= $(shell pkg-config --exists alsa && echo 1)
-    # support VA-API video output module
-VAAPI ?= $(shell pkg-config --exists libva && echo 1)
-    # use ffmpeg libswscale
-SWSCALE ?= $(shell pkg-config --exists libswscale && echo 1)
-    # use ffmpeg libswresample
-SWRESAMPLE ?= $(shell pkg-config --exists libswresample && echo 1)
-
 #CONFIG := -DDEBUG			# enable debug output+functions
 CONFIG += -DAV_INFO -DAV_INFO_TIME=3000	# info/debug a/v sync
 
@@ -49,6 +40,9 @@ ifeq ($(CXXFLAGS),)
 $(warning CXXFLAGS not set)
 endif
 
+_CFLAGS += $(shell pkg-config --cflags alsa libva libavcodec libswscale libswresample x11 x11-xcb xcb xcb-icccm)
+LIBS += -lrt $(shell pkg-config --libs alsa libva libavcodec libswscale libswresample x11 x11-xcb xcb xcb-icccm)
+
 ### The version number of VDR's plugin API:
 
 APIVERSION = $(call PKGCFG,apiversion)
@@ -65,28 +59,6 @@ PACKAGE = vdr-$(ARCHIVE)
 ### The name of the shared object file:
 
 SOFILE = libvdr-$(PLUGIN).so
-
-### Parse vaapidevice config
-
-ifeq ($(ALSA),1)
-_CFLAGS += $(shell pkg-config --cflags alsa)
-LIBS += $(shell pkg-config --libs alsa)
-endif
-ifeq ($(VAAPI),1)
-_CFLAGS += $(shell pkg-config --cflags libva-x11 libva)
-LIBS += $(shell pkg-config --libs libva-x11 libva)
-endif
-ifeq ($(SWSCALE),1)
-_CFLAGS += $(shell pkg-config --cflags libswscale)
-LIBS += $(shell pkg-config --libs libswscale)
-endif
-ifeq ($(SWRESAMPLE),1)
-_CFLAGS += $(shell pkg-config --cflags libswresample)
-LIBS += $(shell pkg-config --libs libswresample)
-endif
-
-_CFLAGS += $(shell pkg-config --cflags libavcodec x11 x11-xcb xcb xcb-icccm)
-LIBS += -lrt $(shell pkg-config --libs libavcodec x11 x11-xcb xcb xcb-icccm)
 
 ### Includes and Defines (add further entries here):
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ PLUGIN = vaapidevice
 ALSA ?= $(shell pkg-config --exists alsa && echo 1)
     # support VA-API video output module
 VAAPI ?= $(shell pkg-config --exists libva && echo 1)
+    # use ffmpeg libswscale
+SWSCALE ?= $(shell pkg-config --exists libswscale && echo 1)
     # use ffmpeg libswresample
 SWRESAMPLE ?= $(shell pkg-config --exists libswresample && echo 1)
 
@@ -73,6 +75,10 @@ endif
 ifeq ($(VAAPI),1)
 _CFLAGS += $(shell pkg-config --cflags libva-x11 libva)
 LIBS += $(shell pkg-config --libs libva-x11 libva)
+endif
+ifeq ($(SWSCALE),1)
+_CFLAGS += $(shell pkg-config --cflags libswscale)
+LIBS += $(shell pkg-config --libs libswscale)
 endif
 ifeq ($(SWRESAMPLE),1)
 _CFLAGS += $(shell pkg-config --cflags libswresample)

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ PLUGIN = vaapidevice
 ALSA ?= $(shell pkg-config --exists alsa && echo 1)
     # support VA-API video output module
 VAAPI ?= $(shell pkg-config --exists libva && echo 1)
-    # support glx output
-OPENGL ?= $(shell pkg-config --exists gl glu && echo 1)
     # use ffmpeg libswresample
 SWRESAMPLE ?= $(shell pkg-config --exists libswresample && echo 1)
 
@@ -75,15 +73,6 @@ endif
 ifeq ($(VAAPI),1)
 _CFLAGS += $(shell pkg-config --cflags libva-x11 libva)
 LIBS += $(shell pkg-config --libs libva-x11 libva)
-ifeq ($(OPENGL),1)
-_CFLAGS += $(shell pkg-config --cflags libva-glx)
-LIBS += $(shell pkg-config --libs libva-glx)
-endif
-endif
-ifeq ($(OPENGL),1)
-CONFIG += -DUSE_GLX
-_CFLAGS += $(shell pkg-config --cflags gl glu)
-LIBS += $(shell pkg-config --libs gl glu)
 endif
 ifeq ($(SWRESAMPLE),1)
 _CFLAGS += $(shell pkg-config --cflags libswresample)

--- a/README
+++ b/README
@@ -168,14 +168,6 @@ Setup: /etc/vdr/setup.conf
 	0 disable soft start of audio/video sync
 	1 enable soft start of audio/video sync
 
-	vaapidevice.BlackPicture = 0
-	0 disable black picture during channel switch
-	1 enable black picture during channel switch
-
-	vaapidevice.ClearOnSwitch = 0
-	0 keep video und audio buffers during channel switch
-	1 clear video and audio buffers on channel switch
-
 	vaapidevice.Video4to3DisplayFormat = 1
 	0 pan and scan
 	1 letter box

--- a/audio.c
+++ b/audio.c
@@ -72,7 +72,6 @@ static const char *AudioModuleName;	///< which audio module to use
 static const AudioModule *AudioUsedModule = &NoopModule;
 static const char *AudioPCMDevice;	///< PCM device name
 static const char *AudioPassthroughDevice;  ///< Passthrough device name
-static char AudioAppendAES;		///< flag automatic append AES
 static const char *AudioMixerDevice;	///< mixer device name
 static const char *AudioMixerChannel;	///< mixer channel name
 static char AudioDoingInit;		///> flag in init, reduce error
@@ -2057,20 +2056,6 @@ void AudioSetPassthroughDevice(const char *device)
 void AudioSetChannel(const char *channel)
 {
     AudioMixerChannel = channel;
-}
-
-/**
-**	Set automatic AES flag handling.
-**
-**	@param onoff	turn setting AES flag on or off
-*/
-void AudioSetAutoAES(int onoff)
-{
-    if (onoff < 0) {
-	AudioAppendAES ^= 1;
-    } else {
-	AudioAppendAES = onoff;
-    }
 }
 
 /**

--- a/audio.h
+++ b/audio.h
@@ -31,7 +31,6 @@ extern void AudioSetDevice(const char *);   ///< set PCM audio device
     /// set pass-through device
 extern void AudioSetPassthroughDevice(const char *);
 extern void AudioSetChannel(const char *);  ///< set mixer channel
-extern void AudioSetAutoAES(int);	///< set automatic AES flag handling
 extern void AudioInit(void);		///< setup audio module
 extern void AudioExit(void);		///< cleanup and exit audio module
 

--- a/codec.c
+++ b/codec.c
@@ -235,6 +235,8 @@ void CodecVideoOpen(VideoDecoder * decoder, int codec_id)
     decoder->VideoCtx->get_buffer2 = Codec_get_buffer2;
     decoder->VideoCtx->draw_horiz_band = NULL;
 
+    av_opt_set_int(decoder->VideoCtx, "refcounted_frames", 1, 0);
+
     //
     //	Prepare frame buffer for decoder
     //

--- a/codec.c
+++ b/codec.c
@@ -7,9 +7,6 @@
 /// This module contains all decoder and codec functions.
 /// It is uses ffmpeg (http://ffmpeg.org) as backend.
 ///
-/// It may work with libav (http://libav.org), but the tests show
-/// many bugs and incompatiblity in it.	 Don't use this shit.
-///
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -84,14 +81,7 @@ char CodecUsePossibleDefectFrames;
 */
 static enum AVPixelFormat Codec_get_format(AVCodecContext * video_ctx, const enum AVPixelFormat *fmt)
 {
-    VideoDecoder *decoder;
-
-    decoder = video_ctx->opaque;
-
-    // bug in ffmpeg 1.1.1, called with zero width or height
-    if (!video_ctx->width || !video_ctx->height) {
-	Error("codec/video: ffmpeg/libav buggy: width or height zero");
-    }
+    VideoDecoder *decoder = video_ctx->opaque;
 
     return Video_get_format(decoder->HwDecoder, video_ctx, fmt);
 }

--- a/codec.c
+++ b/codec.c
@@ -204,7 +204,7 @@ void CodecVideoOpen(VideoDecoder * decoder, int codec_id)
     decoder->VideoCtx->thread_count = 1;
     pthread_mutex_lock(&CodecLockMutex);
     // open codec
-    if (video_codec->capabilities & (CODEC_CAP_AUTO_THREADS)) {
+    if (video_codec->capabilities & (AV_CODEC_CAP_AUTO_THREADS)) {
 	Debug(3, "Auto threads enabled");
 	decoder->VideoCtx->thread_count = 0;
     }

--- a/codec.c
+++ b/codec.c
@@ -61,7 +61,6 @@ static pthread_mutex_t CodecLockMutex;
 
     /// Flag prefer fast channel switch
 char CodecUsePossibleDefectFrames;
-
 //----------------------------------------------------------------------------
 //  Video
 //----------------------------------------------------------------------------
@@ -167,7 +166,6 @@ void CodecVideoDelDecoder(VideoDecoder * decoder)
 void CodecVideoOpen(VideoDecoder * decoder, int codec_id)
 {
     AVCodec *video_codec;
-    AVBufferRef *hw_device_ctx;
 
     Debug(3, "codec: using video codec ID %#06x (%s)", codec_id, avcodec_get_name(codec_id));
 
@@ -185,10 +183,10 @@ void CodecVideoOpen(VideoDecoder * decoder, int codec_id)
 	Fatal("codec: can't allocate video codec context");
     }
 
-    if (av_hwdevice_ctx_create(&hw_device_ctx, AV_HWDEVICE_TYPE_VAAPI, X11DisplayName, NULL, 0)) {
-	Fatal("codec: can't allocate HW video codec context");
+    if (!HwDeviceContext) {
+	Fatal("codec: no hw device context to be used");
     }
-    decoder->VideoCtx->hw_device_ctx = av_buffer_ref(hw_device_ctx);
+    decoder->VideoCtx->hw_device_ctx = av_buffer_ref(HwDeviceContext);
 
     // FIXME: for software decoder use all cpus, otherwise 1
     decoder->VideoCtx->thread_count = 1;
@@ -257,8 +255,6 @@ void CodecVideoClose(VideoDecoder * video_decoder)
 	av_freep(&video_decoder->VideoCtx);
 	pthread_mutex_unlock(&CodecLockMutex);
     }
-
-    av_buffer_unref(&video_decoder->HwDeviceContext);
 }
 
 /**

--- a/codec.c
+++ b/codec.c
@@ -30,6 +30,7 @@
 #error "libavcodec is too old - please, upgrade!"
 #endif
 #include <libavutil/mem.h>
+#include <libavutil/opt.h>
 #include <libavcodec/vaapi.h>
 #include <libavutil/hwcontext.h>
 #include <libavutil/hwcontext_vaapi.h>
@@ -204,7 +205,7 @@ void CodecVideoOpen(VideoDecoder * decoder, int codec_id)
     pthread_mutex_lock(&CodecLockMutex);
     // open codec
     if (video_codec->capabilities & (CODEC_CAP_AUTO_THREADS)) {
-	printf("Auto threads!\n");
+	Debug(3, "Auto threads enabled");
 	decoder->VideoCtx->thread_count = 0;
     }
 

--- a/codec.c
+++ b/codec.c
@@ -59,8 +59,6 @@
       ///
 static pthread_mutex_t CodecLockMutex;
 
-    /// Flag prefer fast channel switch
-char CodecUsePossibleDefectFrames;
 //----------------------------------------------------------------------------
 //  Video
 //----------------------------------------------------------------------------

--- a/codec.c
+++ b/codec.c
@@ -195,7 +195,7 @@ void CodecVideoOpen(VideoDecoder * decoder, int codec_id)
 	Fatal("codec: can't allocate video codec context");
     }
 
-    if (av_hwdevice_ctx_create(&hw_device_ctx, AV_HWDEVICE_TYPE_VAAPI, NULL, NULL, 0)) {
+    if (av_hwdevice_ctx_create(&hw_device_ctx, AV_HWDEVICE_TYPE_VAAPI, X11DisplayName, NULL, 0)) {
 	Fatal("codec: can't allocate HW video codec context");
     }
     decoder->VideoCtx->hw_device_ctx = av_buffer_ref(hw_device_ctx);

--- a/codec.h
+++ b/codec.h
@@ -46,7 +46,6 @@ struct _video_decoder_
 {
     VideoHwDecoder *HwDecoder;		///< video hardware decoder
 
-    int GetFormatDone;			///< flag get format called!
     AVCodec *VideoCodec;		///< video codec
     AVCodecContext *VideoCtx;		///< video codec context
     int FirstKeyFrame;			///< flag first frame
@@ -59,7 +58,6 @@ struct _video_decoder_
 
     /* hwaccel context */
     AVBufferRef *HwDeviceContext;	///< ffmpeg HW-Accelerated (VA-API) context
-    AVVAAPIHWConfig *HwDeviceConfig;	///< ffmpeg HW-Accelerated (VA-API) config
 
     enum HWAccelID active_hwaccel_id;
     void *hwaccel_ctx;

--- a/codec.h
+++ b/codec.h
@@ -47,9 +47,6 @@ typedef struct _audio_decoder_ AudioDecoder;
     /// x11 display name
 extern const char *X11DisplayName;
 
-    /// Flag prefer fast xhannel switch
-extern char CodecUsePossibleDefectFrames;
-
     /// HW device context from video module
 extern AVBufferRef *HwDeviceContext;
 //----------------------------------------------------------------------------

--- a/codec.h
+++ b/codec.h
@@ -65,6 +65,9 @@ typedef struct _audio_decoder_ AudioDecoder;
 //  Variables
 //----------------------------------------------------------------------------
 
+    /// x11 display name
+extern const char *X11DisplayName;
+
     /// Flag prefer fast xhannel switch
 extern char CodecUsePossibleDefectFrames;
 

--- a/codec.h
+++ b/codec.h
@@ -7,9 +7,6 @@
 //  Defines
 //----------------------------------------------------------------------------
 
-#include <libavutil/hwcontext.h>
-#include <libavutil/hwcontext_vaapi.h>
-
 #define CodecPCM 0x01			///< PCM bit mask
 #define CodecMPA 0x02			///< MPA bit mask (planned)
 #define CodecAC3 0x04			///< AC-3 bit mask
@@ -17,12 +14,6 @@
 #define CodecDTS 0x10			///< DTS bit mask (planned)
 
 #define AVCODEC_MAX_AUDIO_FRAME_SIZE 192000
-
-#define TO_AVHW_DEVICE_CTX(x) ((AVHWDeviceContext*)x->data)
-#define TO_AVHW_FRAMES_CTX(x) ((AVHWFramesContext*)x->data)
-
-#define TO_VAAPI_DEVICE_CTX(x) ((AVVAAPIDeviceContext*)TO_AVHW_DEVICE_CTX(x)->hwctx)
-#define TO_VAAPI_FRAMES_CTX(x) ((AVVAAPIFramesContext*)TO_AVHW_FRAMES_CTX(x)->hwctx)
 
 enum HWAccelID
 {

--- a/codec.h
+++ b/codec.h
@@ -15,19 +15,6 @@
 
 #define AVCODEC_MAX_AUDIO_FRAME_SIZE 192000
 
-enum HWAccelID
-{
-    HWACCEL_NONE = 0,
-    HWACCEL_AUTO,
-    HWACCEL_VDPAU,
-    HWACCEL_DXVA2,
-    HWACCEL_VDA,
-    HWACCEL_VIDEOTOOLBOX,
-    HWACCEL_QSV,
-    HWACCEL_VAAPI,
-    HWACCEL_CUVID,
-};
-
 AVBufferRef *hw_device_ctx;
 
 ///
@@ -43,7 +30,6 @@ struct _video_decoder_
     AVFrame *Frame;			///< decoded video frame
 
     /* hwaccel options */
-    enum HWAccelID hwaccel_id;
     char *hwaccel_device;
     enum AVPixelFormat hwaccel_output_format;
 

--- a/codec.h
+++ b/codec.h
@@ -49,6 +49,7 @@ extern const char *X11DisplayName;
 
     /// HW device context from video module
 extern AVBufferRef *HwDeviceContext;
+
 //----------------------------------------------------------------------------
 //  Prototypes
 //----------------------------------------------------------------------------

--- a/codec.h
+++ b/codec.h
@@ -49,15 +49,6 @@ struct _video_decoder_
 
     /* hwaccel context */
     AVBufferRef *HwDeviceContext;	///< ffmpeg HW-Accelerated (VA-API) context
-
-    enum HWAccelID active_hwaccel_id;
-    void *hwaccel_ctx;
-    void (*hwaccel_uninit) (AVCodecContext * s);
-    int (*hwaccel_get_buffer) (AVCodecContext * s, AVFrame * frame, int flags);
-    int (*hwaccel_retrieve_data) (AVCodecContext * s, AVFrame * frame);
-    enum AVPixelFormat hwaccel_pix_fmt;
-    enum AVPixelFormat hwaccel_retrieved_pix_fmt;
-    AVBufferRef *hw_frames_ctx;
 };
 
 //----------------------------------------------------------------------------

--- a/codec.h
+++ b/codec.h
@@ -3,6 +3,8 @@
 ///
 /// SPDX-License-Identifier: AGPL-3.0-only
 
+#include <libavutil/hwcontext.h>
+
 //----------------------------------------------------------------------------
 //  Defines
 //----------------------------------------------------------------------------
@@ -15,8 +17,6 @@
 
 #define AVCODEC_MAX_AUDIO_FRAME_SIZE 192000
 
-AVBufferRef *hw_device_ctx;
-
 ///
 /// Video decoder structure.
 ///
@@ -28,13 +28,6 @@ struct _video_decoder_
     AVCodecContext *VideoCtx;		///< video codec context
     int FirstKeyFrame;			///< flag first frame
     AVFrame *Frame;			///< decoded video frame
-
-    /* hwaccel options */
-    char *hwaccel_device;
-    enum AVPixelFormat hwaccel_output_format;
-
-    /* hwaccel context */
-    AVBufferRef *HwDeviceContext;	///< ffmpeg HW-Accelerated (VA-API) context
 };
 
 //----------------------------------------------------------------------------
@@ -57,6 +50,8 @@ extern const char *X11DisplayName;
     /// Flag prefer fast xhannel switch
 extern char CodecUsePossibleDefectFrames;
 
+    /// HW device context from video module
+extern AVBufferRef *HwDeviceContext;
 //----------------------------------------------------------------------------
 //  Prototypes
 //----------------------------------------------------------------------------

--- a/codec.h
+++ b/codec.h
@@ -7,6 +7,9 @@
 //  Defines
 //----------------------------------------------------------------------------
 
+#include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_vaapi.h>
+
 #define CodecPCM 0x01			///< PCM bit mask
 #define CodecMPA 0x02			///< MPA bit mask (planned)
 #define CodecAC3 0x04			///< AC-3 bit mask
@@ -14,6 +17,12 @@
 #define CodecDTS 0x10			///< DTS bit mask (planned)
 
 #define AVCODEC_MAX_AUDIO_FRAME_SIZE 192000
+
+#define TO_AVHW_DEVICE_CTX(x) ((AVHWDeviceContext*)x->data)
+#define TO_AVHW_FRAMES_CTX(x) ((AVHWFramesContext*)x->data)
+
+#define TO_VAAPI_DEVICE_CTX(x) ((AVVAAPIDeviceContext*)TO_AVHW_DEVICE_CTX(x)->hwctx)
+#define TO_VAAPI_FRAMES_CTX(x) ((AVVAAPIFramesContext*)TO_AVHW_FRAMES_CTX(x)->hwctx)
 
 enum HWAccelID
 {
@@ -49,6 +58,9 @@ struct _video_decoder_
     enum AVPixelFormat hwaccel_output_format;
 
     /* hwaccel context */
+    AVBufferRef *HwDeviceContext;	///< ffmpeg HW-Accelerated (VA-API) context
+    AVVAAPIHWConfig *HwDeviceConfig;	///< ffmpeg HW-Accelerated (VA-API) config
+
     enum HWAccelID active_hwaccel_id;
     void *hwaccel_ctx;
     void (*hwaccel_uninit) (AVCodecContext * s);

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -64,12 +64,6 @@ msgstr "60Hz Anzeigemodus"
 msgid "Soft start a/v sync"
 msgstr "Sanftanlauf A/V Sync"
 
-msgid "Black during channel switch"
-msgstr "Schwarz während Kanalwechsel"
-
-msgid "Clear decoder on channel switch"
-msgstr "Decoder bei Kanalwechsel leeren"
-
 #, c-format
 msgid "Brightness (%d..[%d]..%d)"
 msgstr "Helligkeit (%d..[%d]..%d)"
@@ -175,9 +169,6 @@ msgstr "Reduziere Steropegel (/1000)"
 
 msgid "Audio buffer size (ms)"
 msgstr "Audio Puffergröße (ms)"
-
-msgid "Enable automatic AES"
-msgstr "Aktiviere automatiche AES"
 
 msgid "Detach VA-API Device"
 msgstr ""

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -37,15 +37,6 @@ msgstr "Erzeuge primäres Gerät"
 msgid "Hide main menu entry"
 msgstr "Verstecke Hauptmenüeintrag"
 
-msgid "Osd size"
-msgstr "OSD Größe"
-
-msgid "Osd width"
-msgstr "OSD Breite"
-
-msgid "Osd height"
-msgstr "OSD Höhe"
-
 msgid "Suspend"
 msgstr "Unterbrechen"
 

--- a/vaapidev.c
+++ b/vaapidev.c
@@ -562,7 +562,7 @@ static void VideoPacketExit(VideoStream * stream)
 **
 **	@param stream	video stream
 **	@param pts	presentation timestamp of pes packet
-**	@param dts	presentation timestamp of pes packet
+**	@param dts	decode timestamp of pes packet
 **	@param data	data of pes packet
 **	@param size	size of pes packet
 */

--- a/vaapidev.c
+++ b/vaapidev.c
@@ -49,7 +49,6 @@ static int ValidateMpeg(const uint8_t * data, int size);
 //////////////////////////////////////////////////////////////////////////////
 
 extern int ConfigAudioBufferTime;	///< config size ms of audio buffer
-extern int ConfigVideoClearOnSwitch;	///< clear decoder on channel switch
 char ConfigStartX11Server;		///< flag start the x11 server
 static signed char ConfigStartSuspended;    ///< flag to start in suspend mode
 static char ConfigFullscreen;		///< fullscreen modus
@@ -2202,7 +2201,7 @@ int SetPlayMode(int play_mode)
 	    // tell video parser we get new stream
 	    if (MyVideoStream->Decoder && !MyVideoStream->SkipStream) {
 		// clear buffers on close configured always or replay only
-		if (ConfigVideoClearOnSwitch || MyVideoStream->ClearClose) {
+		if (MyVideoStream->ClearClose) {
 		    Clear();		// flush all buffers
 		    MyVideoStream->ClearClose = 0;
 		}

--- a/vaapidev.c
+++ b/vaapidev.c
@@ -2596,8 +2596,7 @@ const char *CommandLineHelp(void)
 	"\talsa-driver-broken\tdisable broken alsa driver message\n"
 	"\talsa-no-close-open\tdisable close open to fix alsa no sound bug\n"
 	"\talsa-close-open-delay\tenable close open delay to fix no sound bug\n"
-	"\tignore-repeat-pict\tdisable repeat pict message\n"
-	"\tuse-possible-defect-frames prefer faster channel switch\n" "	 -D\t\tstart in detached mode\n";
+	"\tignore-repeat-pict\tdisable repeat pict message\n" "	 -D\t\tstart in detached mode\n";
 }
 
 /**
@@ -2671,8 +2670,6 @@ int ProcessArgs(int argc, char *const argv[])
 		    AudioAlsaCloseOpenDelay = 1;
 		} else if (!strcasecmp("ignore-repeat-pict", optarg)) {
 		    VideoIgnoreRepeatPict = 1;
-		} else if (!strcasecmp("use-possible-defect-frames", optarg)) {
-		    CodecUsePossibleDefectFrames = 1;
 		} else {
 		    fprintf(stderr, "Workaround '%s' unsupported\n", optarg);
 		    return 0;

--- a/vaapidev.c
+++ b/vaapidev.c
@@ -562,10 +562,11 @@ static void VideoPacketExit(VideoStream * stream)
 **
 **	@param stream	video stream
 **	@param pts	presentation timestamp of pes packet
+**	@param dts	presentation timestamp of pes packet
 **	@param data	data of pes packet
 **	@param size	size of pes packet
 */
-static void VideoEnqueue(VideoStream * stream, int64_t pts, const void *data, int size)
+static void VideoEnqueue(VideoStream * stream, int64_t pts, int64_t dts, const void *data, int size)
 {
     AVPacket *avpkt;
 
@@ -574,6 +575,7 @@ static void VideoEnqueue(VideoStream * stream, int64_t pts, const void *data, in
     avpkt = &stream->PacketRb[stream->PacketWrite];
     if (!avpkt->stream_index) {		// add pts only for first added
 	avpkt->pts = pts;
+	avpkt->dts = dts;
     }
     if (avpkt->stream_index + size >= avpkt->size) {
 
@@ -672,10 +674,11 @@ static void VideoNextPacket(VideoStream * stream, int codec_id)
 **
 **     @param stream   video stream
 **     @param pts      presentation timestamp of pes packet
+**     @param dts      presentation timestamp of pes packet
 **     @param data     data of pes packet
 **     @param size     size of pes packet
 */
-static void VideoMpegEnqueue(VideoStream * stream, int64_t pts, const void *data, int size)
+static void VideoMpegEnqueue(VideoStream * stream, int64_t pts, int64_t dts, const void *data, int size)
 {
     static const char startcode[3] = { 0x00, 0x00, 0x01 };
     const uint8_t *p;
@@ -692,33 +695,36 @@ static void VideoMpegEnqueue(VideoStream * stream, int64_t pts, const void *data
 	    if (!p[0] || p[0] == 0xb3) {
 		stream->PacketRb[stream->PacketWrite].stream_index -= 3;
 		VideoNextPacket(stream, AV_CODEC_ID_MPEG2VIDEO);
-		VideoEnqueue(stream, pts, startcode, 3);
+		VideoEnqueue(stream, pts, dts, startcode, 3);
 		first = p[0] == 0xb3;
 		p++;
 		n--;
 		pts = AV_NOPTS_VALUE;
+		dts = AV_NOPTS_VALUE;
 	    }
 	    break;
 	case 2:			       // 0x00 0x00 seen
 	    if (p[0] == 0x01 && (!p[1] || p[1] == 0xb3)) {
 		stream->PacketRb[stream->PacketWrite].stream_index -= 2;
 		VideoNextPacket(stream, AV_CODEC_ID_MPEG2VIDEO);
-		VideoEnqueue(stream, pts, startcode, 2);
+		VideoEnqueue(stream, pts, dts, startcode, 2);
 		first = p[1] == 0xb3;
 		p += 2;
 		n -= 2;
 		pts = AV_NOPTS_VALUE;
+		dts = AV_NOPTS_VALUE;
 	    }
 	    break;
 	case 1:			       // 0x00 seen
 	    if (!p[0] && p[1] == 0x01 && (!p[2] || p[2] == 0xb3)) {
 		stream->PacketRb[stream->PacketWrite].stream_index -= 1;
 		VideoNextPacket(stream, AV_CODEC_ID_MPEG2VIDEO);
-		VideoEnqueue(stream, pts, startcode, 1);
+		VideoEnqueue(stream, pts, dts, startcode, 1);
 		first = p[2] == 0xb3;
 		p += 3;
 		n -= 3;
 		pts = AV_NOPTS_VALUE;
+		dts = AV_NOPTS_VALUE;
 	    }
 	case 0:
 	    break;
@@ -739,13 +745,14 @@ static void VideoMpegEnqueue(VideoStream * stream, int64_t pts, const void *data
 	    }
 	    // packet has already an picture header
 	    // first packet goes only upto picture header
-	    VideoEnqueue(stream, pts, data, p - p2);
+	    VideoEnqueue(stream, pts, dts, data, p - p2);
 	    VideoNextPacket(stream, AV_CODEC_ID_MPEG2VIDEO);
 	    data = p;
 	    size = n;
 
 	    // time-stamp only valid for first packet
 	    pts = AV_NOPTS_VALUE;
+	    dts = AV_NOPTS_VALUE;
 	    n -= 4;
 	    p += 4;
 	    continue;
@@ -774,7 +781,7 @@ static void VideoMpegEnqueue(VideoStream * stream, int64_t pts, const void *data
 	case 0:
 	    break;
     }
-    VideoEnqueue(stream, pts, data, size);
+    VideoEnqueue(stream, pts, dts, data, size);
 }
 
 /**
@@ -1380,7 +1387,8 @@ static void PesParse(PesDemux * pesdx, const uint8_t * data, int size, int is_st
 				    static uint8_t seq_end_h264[] = { 0x00, 0x00, 0x00, 0x01, 0x0A };
 
 				    VideoNextPacket(MyVideoStream, AV_CODEC_ID_H264);
-				    VideoEnqueue(MyVideoStream, AV_NOPTS_VALUE, seq_end_h264, sizeof(seq_end_h264));
+				    VideoEnqueue(MyVideoStream, AV_NOPTS_VALUE, AV_NOPTS_VALUE, seq_end_h264,
+					sizeof(seq_end_h264));
 				}
 			    }
 			    VideoNextPacket(MyVideoStream, AV_CODEC_ID_H264);
@@ -1389,9 +1397,10 @@ static void PesParse(PesDemux * pesdx, const uint8_t * data, int size, int is_st
 			    MyVideoStream->CodecID = AV_CODEC_ID_H264;
 			}
 			// (ffmpeg supports short start code)
-			VideoEnqueue(MyVideoStream, pesdx->PTS, check - 2, l + 2);
+			VideoEnqueue(MyVideoStream, pesdx->PTS, pesdx->DTS, check - 2, l + 2);
 			pesdx->Skip += n;
 			pesdx->PTS = AV_NOPTS_VALUE;
+			pesdx->DTS = AV_NOPTS_VALUE;
 			break;
 		    }
 		    // HEVC Codec
@@ -1404,9 +1413,10 @@ static void PesParse(PesDemux * pesdx, const uint8_t * data, int size, int is_st
 			    MyVideoStream->CodecID = AV_CODEC_ID_HEVC;
 			}
 			// (ffmpeg supports short start code)
-			VideoEnqueue(MyVideoStream, pesdx->PTS, check - 2, l + 2);
+			VideoEnqueue(MyVideoStream, pesdx->PTS, pesdx->DTS, check - 2, l + 2);
 			pesdx->Skip += n;
 			pesdx->PTS = AV_NOPTS_VALUE;
+			pesdx->DTS = AV_NOPTS_VALUE;
 			break;
 		    }
 		    // PES start code 0x00 0x00 0x01 0x00|0xb3
@@ -1422,9 +1432,10 @@ static void PesParse(PesDemux * pesdx, const uint8_t * data, int size, int is_st
 			    Debug(3, "vaapidevice/video: invalid mpeg2 video packet");
 			}
 #endif
-			VideoMpegEnqueue(MyVideoStream, pesdx->PTS, check - 2, l + 2);
+			VideoMpegEnqueue(MyVideoStream, pesdx->PTS, pesdx->DTS, check - 2, l + 2);
 			pesdx->Skip += n;
 			pesdx->PTS = AV_NOPTS_VALUE;
+			pesdx->DTS = AV_NOPTS_VALUE;
 			break;
 		    }
 
@@ -1432,12 +1443,13 @@ static void PesParse(PesDemux * pesdx, const uint8_t * data, int size, int is_st
 			Debug(3, "video: not detected");
 			pesdx->Skip += n;
 			pesdx->PTS = AV_NOPTS_VALUE;
+			pesdx->DTS = AV_NOPTS_VALUE;
 			break;
 		    }
 		    if (MyVideoStream->CodecID == AV_CODEC_ID_MPEG2VIDEO) {
-			VideoMpegEnqueue(MyVideoStream, pesdx->PTS, q, n);
+			VideoMpegEnqueue(MyVideoStream, pesdx->PTS, pesdx->DTS, q, n);
 		    } else {
-			VideoEnqueue(MyVideoStream, pesdx->PTS, q, n);
+			VideoEnqueue(MyVideoStream, pesdx->PTS, pesdx->DTS, q, n);
 		    }
 		    pesdx->Skip += n;
 		}
@@ -1906,6 +1918,7 @@ int PlayVideo3(VideoStream * stream, const uint8_t * data, int size)
 {
     const uint8_t *check;
     int64_t pts;
+    int64_t dts;
     int n;
     int z;
     int l;
@@ -1964,9 +1977,17 @@ int PlayVideo3(VideoStream * stream, const uint8_t * data, int size)
     }
     // get pts/dts
     pts = AV_NOPTS_VALUE;
-    if (data[7] & 0x80) {
+    dts = AV_NOPTS_VALUE;
+    if ((data[7] & 0xC0) == 0x80) {
 	pts =
 	    (int64_t) (data[9] & 0x0E) << 29 | data[10] << 22 | (data[11] & 0xFE) << 14 | data[12] << 7 | (data[13] &
+	    0xFE) >> 1;
+    } else if ((data[7] & 0xC0) == 0xC0) {
+	pts =
+	    (int64_t) (data[9] & 0x0E) << 29 | data[10] << 22 | (data[11] & 0xFE) << 14 | data[12] << 7 | (data[13] &
+	    0xFE) >> 1;
+	dts =
+	    (int64_t) (data[14] & 0x0E) << 29 | data[15] << 22 | (data[16] & 0xFE) << 14 | data[17] << 7 | (data[18] &
 	    0xFE) >> 1;
     }
 
@@ -2014,7 +2035,7 @@ int PlayVideo3(VideoStream * stream, const uint8_t * data, int size)
 		    static uint8_t seq_end_h264[] = { 0x00, 0x00, 0x00, 0x01, 0x0A };
 
 		    VideoNextPacket(stream, AV_CODEC_ID_H264);
-		    VideoEnqueue(stream, AV_NOPTS_VALUE, seq_end_h264, sizeof(seq_end_h264));
+		    VideoEnqueue(stream, AV_NOPTS_VALUE, AV_NOPTS_VALUE, seq_end_h264, sizeof(seq_end_h264));
 		}
 	    }
 	    VideoNextPacket(stream, AV_CODEC_ID_H264);
@@ -2023,7 +2044,7 @@ int PlayVideo3(VideoStream * stream, const uint8_t * data, int size)
 	    stream->CodecID = AV_CODEC_ID_H264;
 	}
 	// SKIP PES header (ffmpeg supports short start code)
-	VideoEnqueue(stream, pts, check - 2, l + 2);
+	VideoEnqueue(stream, pts, dts, check - 2, l + 2);
 	return size;
     }
     // HEVC Codec
@@ -2036,7 +2057,7 @@ int PlayVideo3(VideoStream * stream, const uint8_t * data, int size)
 	    stream->CodecID = AV_CODEC_ID_HEVC;
 	}
 	// SKIP PES header (ffmpeg supports short start code)
-	VideoEnqueue(stream, pts, check - 2, l + 2);
+	VideoEnqueue(stream, pts, dts, check - 2, l + 2);
 	return size;
     }
     // PES start code 0x00 0x00 0x01 0x00|0xb3
@@ -2053,7 +2074,7 @@ int PlayVideo3(VideoStream * stream, const uint8_t * data, int size)
 	}
 #endif
 	// SKIP PES header, begin of start code
-	VideoMpegEnqueue(stream, pts, check - 2, l + 2);
+	VideoMpegEnqueue(stream, pts, dts, check - 2, l + 2);
 	return size;
     }
     // this happens when vdr sends incomplete packets
@@ -2063,10 +2084,10 @@ int PlayVideo3(VideoStream * stream, const uint8_t * data, int size)
     }
     if (stream->CodecID == AV_CODEC_ID_MPEG2VIDEO) {
 	// SKIP PES header
-	VideoMpegEnqueue(stream, pts, data + 9 + n, size - 9 - n);
+	VideoMpegEnqueue(stream, pts, dts, data + 9 + n, size - 9 - n);
     } else {
 	// SKIP PES header
-	VideoEnqueue(stream, pts, data + 9 + n, size - 9 - n);
+	VideoEnqueue(stream, pts, dts, data + 9 + n, size - 9 - n);
     }
 
     return size;
@@ -2425,14 +2446,14 @@ void StillPicture(const uint8_t * data, int size)
 		VideoNextPacket(MyVideoStream, AV_CODEC_ID_NONE);   // close last stream
 		MyVideoStream->CodecID = AV_CODEC_ID_MPEG2VIDEO;
 	    }
-	    VideoEnqueue(MyVideoStream, AV_NOPTS_VALUE, data, size);
+	    VideoEnqueue(MyVideoStream, AV_NOPTS_VALUE, AV_NOPTS_VALUE, data, size);
 	}
 	if (MyVideoStream->CodecID == AV_CODEC_ID_H264) {
-	    VideoEnqueue(MyVideoStream, AV_NOPTS_VALUE, seq_end_h264, sizeof(seq_end_h264));
+	    VideoEnqueue(MyVideoStream, AV_NOPTS_VALUE, AV_NOPTS_VALUE, seq_end_h264, sizeof(seq_end_h264));
 	} else if (MyVideoStream->CodecID == AV_CODEC_ID_HEVC) {
-	    VideoEnqueue(MyVideoStream, AV_NOPTS_VALUE, seq_end_h265, sizeof(seq_end_h265));
+	    VideoEnqueue(MyVideoStream, AV_NOPTS_VALUE, AV_NOPTS_VALUE, seq_end_h265, sizeof(seq_end_h265));
 	} else {
-	    VideoEnqueue(MyVideoStream, AV_NOPTS_VALUE, seq_end_mpeg, sizeof(seq_end_mpeg));
+	    VideoEnqueue(MyVideoStream, AV_NOPTS_VALUE, AV_NOPTS_VALUE, seq_end_mpeg, sizeof(seq_end_mpeg));
 	}
 	VideoNextPacket(MyVideoStream, MyVideoStream->CodecID); // terminate last packet
     }

--- a/vaapidev.c
+++ b/vaapidev.c
@@ -581,7 +581,7 @@ static void VideoEnqueue(VideoStream * stream, int64_t pts, int64_t dts, const v
 
 	Warning("video: packet buffer too small for %d", avpkt->stream_index + size);
 
-	// new + grow reserves FF_INPUT_BUFFER_PADDING_SIZE
+	// new + grow reserves AV_INPUT_BUFFER_PADDING_SIZE
 	av_grow_packet(avpkt, ((size + VIDEO_BUFFER_SIZE / 2)
 		/ (VIDEO_BUFFER_SIZE / 2)) * (VIDEO_BUFFER_SIZE / 2));
 	// FIXME: out of memory!
@@ -648,7 +648,7 @@ static void VideoNextPacket(VideoStream * stream, int codec_id)
 	return;
     }
     // clear area for decoder, always enough space allocated
-    memset(avpkt->data + avpkt->stream_index, 0, FF_INPUT_BUFFER_PADDING_SIZE);
+    memset(avpkt->data + avpkt->stream_index, 0, AV_INPUT_BUFFER_PADDING_SIZE);
 
     stream->CodecIDRb[stream->PacketWrite] = codec_id;
     //DumpH264(avpkt->data, avpkt->stream_index);
@@ -1201,7 +1201,7 @@ static void PesInit(PesDemux * pesdx)
 {
     memset(pesdx, 0, sizeof(*pesdx));
     pesdx->Size = PES_MAX_PAYLOAD;
-    pesdx->Buffer = av_malloc(PES_MAX_PAYLOAD + FF_INPUT_BUFFER_PADDING_SIZE);
+    pesdx->Buffer = av_malloc(PES_MAX_PAYLOAD + AV_INPUT_BUFFER_PADDING_SIZE);
     if (!pesdx->Buffer) {
 	Fatal("pesdemux: out of memory");
     }

--- a/vaapidevice.cpp
+++ b/vaapidevice.cpp
@@ -70,8 +70,6 @@ static uint32_t ConfigVideoBackground;	///< config video background color
 static char ConfigVideoStudioLevels;	///< config use studio levels
 static char ConfigVideo60HzMode;	///< config use 60Hz display mode
 static char ConfigVideoSoftStartSync;	///< config use softstart sync
-static char ConfigVideoBlackPicture;	///< config enable black picture mode
-char ConfigVideoClearOnSwitch;		///< config enable Clear on channel switch
 
 static int ConfigVideoBrightness;	///< config video brightness
 static int ConfigVideoContrast = 1000;	///< config video contrast
@@ -114,7 +112,6 @@ static char ConfigAudioCompression;	///< config use volume compression
 static int ConfigAudioMaxCompression;	///< config max volume compression
 static int ConfigAudioStereoDescent;	///< config reduce stereo loudness
 int ConfigAudioBufferTime;		///< config size ms of audio buffer
-static int ConfigAudioAutoAES;		///< config automatic AES handling
 
 static char *ConfigX11Display;		///< config x11 display
 static char *ConfigAudioDevice;		///< config audio stereo device
@@ -565,8 +562,6 @@ class cMenuSetupSoft:public cMenuSetupPage
     int StudioLevels;
     int _60HzMode;
     int SoftStartSync;
-    int BlackPicture;
-    int ClearOnSwitch;
 
     int Brightness;
     int Contrast;
@@ -601,7 +596,6 @@ class cMenuSetupSoft:public cMenuSetupPage
     int AudioMaxCompression;
     int AudioStereoDescent;
     int AudioBufferTime;
-    int AudioAutoAES;
 
     /// @}
   private:
@@ -719,8 +713,6 @@ void cMenuSetupSoft::Create(void)
 	Add(new cMenuEditIntItem(tr("Video background color (Alpha)"), (int *)&BackgroundAlpha, 0, 0xFF));
 	Add(new cMenuEditBoolItem(tr("60hz display mode"), &_60HzMode, trVDR("no"), trVDR("yes")));
 	Add(new cMenuEditBoolItem(tr("Soft start a/v sync"), &SoftStartSync, trVDR("no"), trVDR("yes")));
-	Add(new cMenuEditBoolItem(tr("Black during channel switch"), &BlackPicture, trVDR("no"), trVDR("yes")));
-	Add(new cMenuEditBoolItem(tr("Clear decoder on channel switch"), &ClearOnSwitch, trVDR("no"), trVDR("yes")));
 
 	if (brightness_active)
 	    Add(new cMenuEditIntItem(*cString::sprintf(tr("Brightness (%d..[%d]..%d)"), brightness_min, brightness_def,
@@ -790,7 +782,6 @@ void cMenuSetupSoft::Create(void)
 	Add(new cMenuEditIntItem(tr("  Max compression factor (/1000)"), &AudioMaxCompression, 0, 10000));
 	Add(new cMenuEditIntItem(tr("Reduce stereo volume (/1000)"), &AudioStereoDescent, 0, 1000));
 	Add(new cMenuEditIntItem(tr("Audio buffer size (ms)"), &AudioBufferTime, 0, 1000));
-	Add(new cMenuEditBoolItem(tr("Enable automatic AES"), &AudioAutoAES, trVDR("no"), trVDR("yes")));
     }
 
     SetCurrent(Get(current));		// restore selected menu entry
@@ -899,8 +890,6 @@ cMenuSetupSoft::cMenuSetupSoft(void)
     StudioLevels = ConfigVideoStudioLevels;
     _60HzMode = ConfigVideo60HzMode;
     SoftStartSync = ConfigVideoSoftStartSync;
-    BlackPicture = ConfigVideoBlackPicture;
-    ClearOnSwitch = ConfigVideoClearOnSwitch;
 
     Brightness = ConfigVideoBrightness;
     Contrast = ConfigVideoContrast;
@@ -943,7 +932,6 @@ cMenuSetupSoft::cMenuSetupSoft(void)
     AudioMaxCompression = ConfigAudioMaxCompression;
     AudioStereoDescent = ConfigAudioStereoDescent;
     AudioBufferTime = ConfigAudioBufferTime;
-    AudioAutoAES = ConfigAudioAutoAES;
 
     Create();
 }
@@ -991,9 +979,6 @@ void cMenuSetupSoft::Store(void)
     VideoSet60HzMode(ConfigVideo60HzMode);
     SetupStore("SoftStartSync", ConfigVideoSoftStartSync = SoftStartSync);
     VideoSetSoftStartSync(ConfigVideoSoftStartSync);
-    SetupStore("BlackPicture", ConfigVideoBlackPicture = BlackPicture);
-    VideoSetBlackPicture(ConfigVideoBlackPicture);
-    SetupStore("ClearOnSwitch", ConfigVideoClearOnSwitch = ClearOnSwitch);
 
     SetupStore("Brightness", ConfigVideoBrightness = Brightness);
     VideoSetBrightness(ConfigVideoBrightness);
@@ -1070,8 +1055,6 @@ void cMenuSetupSoft::Store(void)
     SetupStore("AudioStereoDescent", ConfigAudioStereoDescent = AudioStereoDescent);
     AudioSetStereoDescent(ConfigAudioStereoDescent);
     SetupStore("AudioBufferTime", ConfigAudioBufferTime = AudioBufferTime);
-    SetupStore("AudioAutoAES", ConfigAudioAutoAES = AudioAutoAES);
-    AudioSetAutoAES(ConfigAudioAutoAES);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -2146,14 +2129,6 @@ bool cPluginVaapiDevice::SetupParse(const char *name, const char *value)
 	VideoSetSoftStartSync(ConfigVideoSoftStartSync = atoi(value));
 	return true;
     }
-    if (!strcasecmp(name, "BlackPicture")) {
-	VideoSetBlackPicture(ConfigVideoBlackPicture = atoi(value));
-	return true;
-    }
-    if (!strcasecmp(name, "ClearOnSwitch")) {
-	ConfigVideoClearOnSwitch = atoi(value);
-	return true;
-    }
     if (!strcasecmp(name, "Brightness")) {
 	VideoSetBrightness(ConfigVideoBrightness = atoi(value));
 	return true;
@@ -2287,11 +2262,6 @@ bool cPluginVaapiDevice::SetupParse(const char *name, const char *value)
     if (!strcasecmp(name, "AudioBufferTime")) {
 	ConfigAudioBufferTime = atoi(value);
 	AudioSetBufferTime(ConfigAudioBufferTime);
-	return true;
-    }
-    if (!strcasecmp(name, "AudioAutoAES")) {
-	ConfigAudioAutoAES = atoi(value);
-	AudioSetAutoAES(ConfigAudioAutoAES);
 	return true;
     }
     return false;

--- a/video.c
+++ b/video.c
@@ -2644,8 +2644,7 @@ static enum AVPixelFormat Vaapi_get_format(VaapiDecoder * decoder, AVCodecContex
 	}
     }
 
-    Error("Failed to get HW surface format");
-    return AV_PIX_FMT_NONE;
+    return  avcodec_default_get_format(video_ctx, fmt);
 }
 
 ///
@@ -3315,9 +3314,9 @@ static void VaapiRenderFrame(VaapiDecoder * decoder, const AVCodecContext * vide
 
 	if (decoder->GetPutImage
 	    && (i =
-		vaPutImage(VaDisplay, surface, decoder->Image->image_id, 0, 0, width, height, 0, 0, width,
-		    height)) != VA_STATUS_SUCCESS) {
-	    Error("video/vaapi: can't put image err:%d!", i);
+		vaPutImage(VaDisplay, surface, decoder->Image->image_id, 0, 0, width, height, 0, 0, VideoWindowWidth,
+		    VideoWindowHeight)) != VA_STATUS_SUCCESS) {
+	    Error("video/vaapi: can't put image err:%s!", vaErrorStr(i));
 	}
 
 	if (!decoder->GetPutImage) {

--- a/video.c
+++ b/video.c
@@ -2018,11 +2018,14 @@ static void VaapiCleanup(VaapiDecoder * decoder)
     }
 #endif
 
+    VaapiOsdExit();
+
     // clear ring buffer
     for (i = 0; i < VIDEO_SURFACES_MAX; ++i) {
 	decoder->SurfacesRb[i] = VA_INVALID_ID;
     }
-    vaDestroySurfaces(VaDisplay, decoder->PostProcSurfacesRb, POSTPROC_SURFACES_MAX);
+    //	cleanup surfaces
+    VaapiDestroySurfaces(decoder);
     for (i = 0; i < POSTPROC_SURFACES_MAX; ++i) {
 	decoder->PostProcSurfacesRb[i] = VA_INVALID_ID;
     }
@@ -2074,10 +2077,6 @@ static void VaapiCleanup(VaapiDecoder * decoder)
     }
     decoder->VppConfig = VA_INVALID_ID;
 
-    //	cleanup surfaces
-    if (decoder->SurfaceFreeN || decoder->SurfaceUsedN) {
-	VaapiDestroySurfaces(decoder);
-    }
 
     decoder->SurfaceRead = 0;
     decoder->SurfaceWrite = 0;
@@ -2849,18 +2848,15 @@ static void VaapiSetupVideoProcessing(VaapiDecoder * decoder);
 ///
 static void VaapiSetup(VaapiDecoder * decoder, const AVCodecContext * video_ctx)
 {
-    int width;
-    int height;
-    VAStatus status;
     VAImageFormat format[1];
+    int width = video_ctx->width;
+    int height = video_ctx->height;
 
     // create initial black surface and display
     VaapiBlackSurface(decoder);
     // cleanup last context
     VaapiCleanup(decoder);
 
-    width = video_ctx->width;
-    height = video_ctx->height;
 #ifdef DEBUG
     // FIXME: remove this if
     if (decoder->Image->image_id != VA_INVALID_ID) {

--- a/video.c
+++ b/video.c
@@ -311,7 +311,6 @@ static VideoZoomModes VideoOtherZoomMode;
 static char Video60HzMode;		///< handle 60hz displays
 static char VideoSoftStartSync;		///< soft start sync audio/video
 static const int VideoSoftStartFrames = 100;	///< soft start frames
-static char VideoShowBlackPicture;	///< flag show black picture
 
 static xcb_atom_t WmDeleteWindowAtom;	///< WM delete message atom
 static xcb_atom_t NetWmState;		///< wm-state message atom
@@ -3634,8 +3633,8 @@ static void VaapiSyncDecoder(VaapiDecoder * decoder)
 	    err =
 		VaapiMessage(1, "video: decoder buffer empty, duping frame (%d/%d) %d v-buf", decoder->FramesDuped,
 		decoder->FrameCounter, VideoGetBuffers(decoder->Stream));
-	    // some time no new picture or black video configured
-	    if (decoder->Closing < -300 || (VideoShowBlackPicture && decoder->Closing)) {
+	    // some time no new picture
+	    if (decoder->Closing < -300) {
 		// clear ring buffer to trigger black picture
 		atomic_set(&decoder->SurfacesFilled, 0);
 	    }
@@ -4955,16 +4954,6 @@ void VideoSet60HzMode(int onoff)
 void VideoSetSoftStartSync(int onoff)
 {
     VideoSoftStartSync = onoff;
-}
-
-///
-/// Set show black picture during channel switch.
-///
-/// @param onoff    enable / disable black picture.
-///
-void VideoSetBlackPicture(int onoff)
-{
-    VideoShowBlackPicture = onoff;
 }
 
 ///

--- a/video.c
+++ b/video.c
@@ -42,7 +42,8 @@
 
 #include <va/va_x11.h>
 #if !VA_CHECK_VERSION(1,0,0)
-#error "libva is too old - please, upgrade!"
+#warning "libva is too old - please, upgrade!"
+#define VA_FOURCC_I420 VA_FOURCC('I', '4', '2', '0')
 #endif
 #include <va/va_vpp.h>
 

--- a/video.c
+++ b/video.c
@@ -1251,8 +1251,6 @@ static VaapiDecoder *VaapiNewHwDecoder(VideoStream * stream)
     return decoder;
 }
 
-static void VaapiOsdExit();
-
 ///
 /// Cleanup VA-API.
 ///

--- a/video.c
+++ b/video.c
@@ -2558,12 +2558,8 @@ static void VaapiSetupVideoProcessing(VaapiDecoder * decoder)
 static int gSurfacePtr = 0;
 static VASurfaceID VaapiGetSurface(VaapiDecoder * decoder, const AVCodecContext * video_ctx)
 {
-    int num_surfaces = TO_VAAPI_FRAMES_CTX(video_ctx->hw_frames_ctx)->nb_surfaces;
     VASurfaceID surface;
-    int x = 0;
-    int y = 0;
-    int w = video_ctx->width;
-    int h = video_ctx->height;
+    int num_surfaces = TO_VAAPI_FRAMES_CTX(video_ctx->hw_frames_ctx)->nb_surfaces;
 
     if (!TO_VAAPI_FRAMES_CTX(video_ctx->hw_frames_ctx)->surface_ids)
 	return VA_INVALID_ID;
@@ -2586,13 +2582,13 @@ static VASurfaceID VaapiGetSurface(VaapiDecoder * decoder, const AVCodecContext 
 
     // FIXME: associate only if osd is displayed
     if (vaAssociateSubpicture(VaDisplay, VaOsdSubpicture, TO_VAAPI_FRAMES_CTX(video_ctx->hw_frames_ctx)->surface_ids,
-	    num_surfaces, x, y, w, h, 0, 0, VideoWindowWidth, VideoWindowHeight,
+	    num_surfaces, 0, 0, VideoWindowWidth, VideoWindowHeight, 0, 0, VideoWindowWidth, VideoWindowHeight,
 	    VA_SUBPICTURE_DESTINATION_IS_SCREEN_COORD)
 	!= VA_STATUS_SUCCESS) {
 	Error("video/vaapi: can't associate subpicture");
     }
 
-    vaAssociateSubpicture(VaDisplay, VaOsdSubpicture, decoder->PostProcSurfacesRb, POSTPROC_SURFACES_MAX, x, y,
+    vaAssociateSubpicture(VaDisplay, VaOsdSubpicture, decoder->PostProcSurfacesRb, POSTPROC_SURFACES_MAX, 0, 0,
 	VideoWindowWidth, VideoWindowHeight, 0, 0, VideoWindowWidth, VideoWindowHeight,
 	VA_SUBPICTURE_DESTINATION_IS_SCREEN_COORD);
 
@@ -4067,14 +4063,11 @@ static void VaapiOsdExit(void)
     }
 
     if (VaOsdSubpicture != VA_INVALID_ID) {
-	int i;
-
-	for (i = 0; i < VaapiDecoderN; ++i) {
+	for (int i = 0; i < VaapiDecoderN; ++i) {
 	    VaapiDeassociate(VaapiDecoders[i]);
 	}
 
-	if (vaDestroySubpicture(VaDisplay, VaOsdSubpicture)
-	    != VA_STATUS_SUCCESS) {
+	if (vaDestroySubpicture(VaDisplay, VaOsdSubpicture) != VA_STATUS_SUCCESS) {
 	    Error("video/vaapi: can't destroy subpicture");
 	}
 	VaOsdSubpicture = VA_INVALID_ID;

--- a/video.c
+++ b/video.c
@@ -88,11 +88,6 @@ typedef enum
 #ifdef USE_GLX
 #include <va/va_glx.h>
 #endif
-#ifndef VA_SURFACE_ATTRIB_SETTABLE
-/// make source compatible with stable libva
-#define vaCreateSurfaces(d, f, w, h, s, ns, a, na) \
-    vaCreateSurfaces(d, w, h, f, ns, s)
-#endif
 
 #include <libavcodec/avcodec.h>
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57,64,100)

--- a/video.c
+++ b/video.c
@@ -3388,7 +3388,7 @@ static enum AVPixelFormat Vaapi_get_format(VaapiDecoder * decoder, AVCodecContex
 	}
     }
 
-    Error("Failed to get HW surface format\n");
+    Error("Failed to get HW surface format");
     return AV_PIX_FMT_NONE;
 }
 

--- a/video.c
+++ b/video.c
@@ -2917,9 +2917,7 @@ static void VaapiSetup(VaapiDecoder * decoder, const AVCodecContext * video_ctx)
 	Error("video/vaapi: can't create config '%s'", vaErrorStr(status));
 	abort();
     }
-    status =
-	vaCreateContext(decoder->VaDisplay, decoder->VppConfig, VideoWindowWidth /*video_ctx->width */ ,
-	VideoWindowHeight /*video_ctx->height */ ,
+    status = vaCreateContext(decoder->VaDisplay, decoder->VppConfig, VideoWindowWidth, VideoWindowHeight,
 	VA_PROGRESSIVE, decoder->PostProcSurfacesRb, POSTPROC_SURFACES_MAX, &decoder->vpp_ctx);
     if (status != VA_STATUS_SUCCESS) {
 	Error("video/vaapi: can't create context '%s'", vaErrorStr(status));
@@ -3317,27 +3315,18 @@ static VASurfaceID VaapiGetSurface(VaapiDecoder * decoder, const AVCodecContext 
 	OsdHeight = VideoWindowHeight;
     }
 
-    VideoUsedModule->OsdInit(VideoWindowWidth, VideoWindowHeight);
+    VideoUsedModule->OsdInit(OsdWidth, OsdHeight);
 
     // FIXME: associate only if osd is displayed
-    if (VaapiUnscaledOsd) {
-	if (vaAssociateSubpicture(VaDisplay, VaOsdSubpicture,
-		TO_VAAPI_FRAMES_CTX(video_ctx->hw_frames_ctx)->surface_ids, num_surfaces, x, y, w, h, 0, 0,
-		VideoWindowWidth, VideoWindowHeight, VA_SUBPICTURE_DESTINATION_IS_SCREEN_COORD)
-	    != VA_STATUS_SUCCESS) {
-	    Error("video/vaapi: can't associate subpicture");
-	}
-    } else {
-	if (vaAssociateSubpicture(VaDisplay, VaOsdSubpicture,
-		TO_VAAPI_FRAMES_CTX(video_ctx->hw_frames_ctx)->surface_ids, num_surfaces, video_ctx->width, y, w, h,
-		decoder->CropX, decoder->CropY / 2, decoder->CropWidth, decoder->CropHeight, 0)
-	    != VA_STATUS_SUCCESS) {
-	    Error("video/vaapi: can't associate subpicture");
-	}
+    if (vaAssociateSubpicture(VaDisplay, VaOsdSubpicture,
+	TO_VAAPI_FRAMES_CTX(video_ctx->hw_frames_ctx)->surface_ids, num_surfaces, x, y, w, h, 0, 0, OsdWidth,
+	    OsdHeight, VA_SUBPICTURE_DESTINATION_IS_SCREEN_COORD)
+	!= VA_STATUS_SUCCESS) {
+	Error("video/vaapi: can't associate subpicture");
     }
 
-    vaAssociateSubpicture(VaDisplay, VaOsdSubpicture, decoder->PostProcSurfacesRb, POSTPROC_SURFACES_MAX, x, y, w, h,
-	0, 0, VideoWindowWidth, VideoWindowHeight, VA_SUBPICTURE_DESTINATION_IS_SCREEN_COORD);
+    vaAssociateSubpicture(VaDisplay, VaOsdSubpicture, decoder->PostProcSurfacesRb, POSTPROC_SURFACES_MAX, x, y,
+	OsdWidth, OsdHeight, 0, 0, VideoWindowWidth, VideoWindowHeight, VA_SUBPICTURE_DESTINATION_IS_SCREEN_COORD);
 
     return surface;
 }

--- a/video.c
+++ b/video.c
@@ -3716,6 +3716,7 @@ static void VaapiSetVideoMode(void)
 	VaapiDecoders[i]->VideoY = 0;
 	VaapiDecoders[i]->VideoWidth = VideoWindowWidth;
 	VaapiDecoders[i]->VideoHeight = VideoWindowHeight;
+	VaapiCleanup(VaapiDecoders[i]);
 	VaapiUpdateOutput(VaapiDecoders[i]);
     }
 }

--- a/video.c
+++ b/video.c
@@ -10,7 +10,6 @@
 /// everything else.
 ///
 
-#define USE_XLIB_XCB			///< use xlib/xcb backend
 #ifndef AV_INFO_TIME
 #define AV_INFO_TIME (50 * 60)		///< a/v info every minute
 #endif
@@ -33,33 +32,13 @@
 #include <signal.h>
 #endif
 
-#ifdef USE_XLIB_XCB
 #include <X11/Xlib-xcb.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
-
 #include <xcb/xcb.h>
-
 #include <xcb/xcb_icccm.h>
-#ifdef XCB_ICCCM_NUM_WM_SIZE_HINTS_ELEMENTS
 #include <xcb/xcb_ewmh.h>
-#else // compatibility hack for old xcb-util
-
-/**
- * @brief Action on the _NET_WM_STATE property
- */
-typedef enum
-{
-    /* Remove/unset property */
-    XCB_EWMH_WM_STATE_REMOVE = 0,
-    /* Add/set property */
-    XCB_EWMH_WM_STATE_ADD = 1,
-    /* Toggle property	*/
-    XCB_EWMH_WM_STATE_TOGGLE = 2
-} xcb_ewmh_wm_state_action_t;
-#endif
-#endif
 
 #include <va/va_x11.h>
 #if !VA_CHECK_VERSION(1,0,0)
@@ -91,8 +70,6 @@ typedef enum
 
 #define TO_VAAPI_DEVICE_CTX(x) ((AVVAAPIDeviceContext*)TO_AVHW_DEVICE_CTX(x)->hwctx)
 #define TO_VAAPI_FRAMES_CTX(x) ((AVVAAPIFramesContext*)TO_AVHW_FRAMES_CTX(x)->hwctx)
-
-#ifdef USE_XLIB_XCB
 
 //----------------------------------------------------------------------------
 //  Declarations
@@ -4835,18 +4812,9 @@ static void VideoCreateWindow(xcb_window_t parent, xcb_visualid_t visual, uint8_
 	VideoWindowHeight, 0, XCB_WINDOW_CLASS_INPUT_OUTPUT, visual,
 	XCB_CW_BACK_PIXEL | XCB_CW_BORDER_PIXEL | XCB_CW_EVENT_MASK | XCB_CW_COLORMAP, values);
 
-    // define only available with xcb-utils-0.3.8
-#ifdef XCB_ICCCM_NUM_WM_SIZE_HINTS_ELEMENTS
     // FIXME: utf _NET_WM_NAME
     xcb_icccm_set_wm_name(Connection, VideoWindow, XCB_ATOM_STRING, 8, sizeof("vaapidevice") - 1, "vaapidevice");
     xcb_icccm_set_wm_icon_name(Connection, VideoWindow, XCB_ATOM_STRING, 8, sizeof("vaapidevice") - 1, "vaapidevice");
-#endif
-    // define only available with xcb-utils-0.3.6
-#ifdef XCB_NUM_WM_HINTS_ELEMENTS
-    // FIXME: utf _NET_WM_NAME
-    xcb_set_wm_name(Connection, VideoWindow, XCB_ATOM_STRING, sizeof("vaapidevice") - 1, "vaapidevice");
-    xcb_set_wm_icon_name(Connection, VideoWindow, XCB_ATOM_STRING, sizeof("vaapidevice") - 1, "vaapidevice");
-#endif
 
     // FIXME: size hints
 
@@ -4859,12 +4827,7 @@ static void VideoCreateWindow(xcb_window_t parent, xcb_visualid_t visual, uint8_
 	if ((reply =
 		xcb_intern_atom_reply(Connection, xcb_intern_atom(Connection, 0, sizeof("WM_PROTOCOLS") - 1,
 			"WM_PROTOCOLS"), NULL))) {
-#ifdef XCB_ICCCM_NUM_WM_SIZE_HINTS_ELEMENTS
 	    xcb_icccm_set_wm_protocols(Connection, VideoWindow, reply->atom, 1, &WmDeleteWindowAtom);
-#endif
-#ifdef XCB_NUM_WM_HINTS_ELEMENTS
-	    xcb_set_wm_protocols(Connection, reply->atom, VideoWindow, 1, &WmDeleteWindowAtom);
-#endif
 	    free(reply);
 	}
     }
@@ -5689,5 +5652,3 @@ void VideoExit(void)
 	Connection = 0;
     }
 }
-
-#endif

--- a/video.c
+++ b/video.c
@@ -3415,24 +3415,20 @@ static void VaapiAdvanceDecoderFrame(VaapiDecoder * decoder)
 ///
 static void VaapiDisplayFrame(void)
 {
-    struct timespec nowtime;
-
 #ifdef DEBUG
     uint32_t start;
-    uint32_t put1;
-    uint32_t put2;
 #endif
-    int i;
+    struct timespec nowtime;
     VaapiDecoder *decoder;
 
     if (VideoSurfaceModesChanged) {	// handle changed modes
 	VideoSurfaceModesChanged = 0;
-	for (i = 0; i < VaapiDecoderN; ++i) {
+	for (int i = 0; i < VaapiDecoderN; ++i) {
 	    VaapiInitSurfaceFlags(VaapiDecoders[i]);
 	}
     }
     // look if any stream have a new surface available
-    for (i = 0; i < VaapiDecoderN; ++i) {
+    for (int i = 0; i < VaapiDecoderN; ++i) {
 	VASurfaceID surface;
 	int filled;
 
@@ -3454,15 +3450,12 @@ static void VaapiDisplayFrame(void)
 	    Debug(4, "video/vaapi: invalid surface in ringbuffer");
 	}
 	Debug(4, "video/vaapi: yy video surface %#010x displayed", surface);
-
 	start = GetMsTicks();
 #endif
-
 	VaapiPutSurfaceX11(decoder, surface, decoder->Interlaced, decoder->Deinterlaced, decoder->TopFieldFirst,
 	    decoder->SurfaceField);
 #ifdef DEBUG
-	put1 = GetMsTicks();
-	put2 = put1;
+	Debug(4, "video/vaapi: put %2ums", GetMsTicks() - start);
 #endif
 	clock_gettime(CLOCK_MONOTONIC, &nowtime);
 	// FIXME: 31 only correct for 50Hz
@@ -3471,7 +3464,6 @@ static void VaapiDisplayFrame(void)
 	    // FIXME: ignore still-frame, trick-speed
 	    Debug(3, "video/vaapi: time/frame too long %ldms", ((nowtime.tv_sec - decoder->FrameTime.tv_sec)
 		    * 1000 * 1000 * 1000 + (nowtime.tv_nsec - decoder->FrameTime.tv_nsec)) / (1000 * 1000));
-	    Debug(4, "video/vaapi: put1 %2u put2 %2u", put1 - start, put2 - put1);
 	}
 	decoder->FrameTime = nowtime;
     }

--- a/video.c
+++ b/video.c
@@ -1860,7 +1860,7 @@ static uint8_t *VaapiGrabOutputSurfaceYUV(VaapiDecoder * decoder, VASurfaceID sr
     VaapiFindImageFormat(decoder, AV_PIX_FMT_NV12, format);
 
     // Sanity check for image format
-    if (image.format.fourcc != VA_FOURCC_NV12 && image.format.fourcc != VA_FOURCC('I', '4', '2', '0')) {
+    if (image.format.fourcc != VA_FOURCC_NV12 && image.format.fourcc != VA_FOURCC_I420) {
 	Error("video/vaapi: Image format mismatch! (fourcc: 0x%x, planes: %d)", image.format.fourcc, image.num_planes);
 	goto out_destroy;
     }
@@ -1888,7 +1888,7 @@ static uint8_t *VaapiGrabOutputSurfaceYUV(VaapiDecoder * decoder, VASurfaceID sr
 
 		u = image_buffer[uv_index];
 		v = image_buffer[uv_index + 1];
-	    } else if (image.format.fourcc == VA_FOURCC('I', '4', '2', '0')) {
+	    } else if (image.format.fourcc == VA_FOURCC_I420) {
 		unsigned int u_index = image.offsets[1] + (image.pitches[1] * (j / 2) + (i / 2));
 		unsigned int v_index = image.offsets[2] + (image.pitches[2] * (j / 2) + (i / 2));
 

--- a/video.c
+++ b/video.c
@@ -15,8 +15,6 @@
 #define AV_INFO_TIME (50 * 60)		///< a/v info every minute
 #endif
 
-//#define USE_VIDEO_THREAD2 ///< run decoder+display in own threads
-
 #include <sys/time.h>
 #include <sys/shm.h>
 #include <sys/ipc.h>
@@ -328,15 +326,6 @@ static pthread_mutex_t VideoMutex;	///< video condition mutex
 static pthread_mutex_t VideoLockMutex;	///< video lock mutex
 extern pthread_mutex_t PTS_mutex;	///< PTS mutex
 extern pthread_mutex_t ReadAdvance_mutex;   ///< PTS mutex
-
-#ifdef USE_VIDEO_THREAD2
-
-static pthread_t VideoDisplayThread;	///< video decode thread
-static pthread_cond_t VideoWakeupCond;	///< wakeup condition variable
-static pthread_mutex_t VideoDisplayMutex;   ///< video condition mutex
-static pthread_mutex_t VideoDisplayLockMutex;	///< video lock mutex
-
-#endif
 
 static char OsdShown;			///< flag show osd
 static int OsdDirtyX;			///< osd dirty area x

--- a/video.c
+++ b/video.c
@@ -112,6 +112,12 @@ typedef enum
 
 #define ARRAY_ELEMS(array) (sizeof(array)/sizeof(array[0]))
 
+#define TO_AVHW_DEVICE_CTX(x) ((AVHWDeviceContext*)x->data)
+#define TO_AVHW_FRAMES_CTX(x) ((AVHWFramesContext*)x->data)
+
+#define TO_VAAPI_DEVICE_CTX(x) ((AVVAAPIDeviceContext*)TO_AVHW_DEVICE_CTX(x)->hwctx)
+#define TO_VAAPI_FRAMES_CTX(x) ((AVVAAPIFramesContext*)TO_AVHW_FRAMES_CTX(x)->hwctx)
+
 #ifdef USE_XLIB_XCB
 
 //----------------------------------------------------------------------------

--- a/video.c
+++ b/video.c
@@ -1622,6 +1622,9 @@ static VAStatus VaapiPostprocessSurface(VAContextID ctx, VASurfaceID src, VASurf
 
     /* Skip postprocessing if queue is not deinterlaceable */
     for (i = 0; i < *num_brefs; ++i) {
+	// Trust the driver to "do the right thing" if invalid surfaces are provided as references
+	if (brefs[i] == VA_INVALID_ID)
+	    continue;
 	va_status = vaQuerySurfaceStatus(VaDisplay, brefs[i], &va_surf_status);
 	if (va_status != VA_STATUS_SUCCESS) {
 	    Error("vaapi/vpp: Surface %d query status failed (0x%X): %s", i, va_status, vaErrorStr(va_status));
@@ -1634,6 +1637,9 @@ static VAStatus VaapiPostprocessSurface(VAContextID ctx, VASurfaceID src, VASurf
     }
 
     for (i = 0; i < *num_frefs; ++i) {
+	// Trust the driver to "do the right thing" if invalid surfaces are provided as references
+	if (frefs[i] == VA_INVALID_ID)
+	    continue;
 	va_status = vaQuerySurfaceStatus(VaDisplay, frefs[i], &va_surf_status);
 	if (va_status != VA_STATUS_SUCCESS) {
 	    Error("Surface %d query status = 0x%X: %s", i, va_status, vaErrorStr(va_status));

--- a/video.c
+++ b/video.c
@@ -9,13 +9,6 @@
 /// Uses Xlib where it is needed for VA-API.  XCB is used for
 /// everything else.
 ///
-/// - X11
-/// - OpenGL rendering
-/// - OpenGL rendering with GLX texture-from-pixmap
-/// - Xrender rendering
-///
-/// @todo FIXME: use vaErrorStr for all VA-API errors.
-///
 
 #define USE_XLIB_XCB			///< use xlib/xcb backend
 #ifndef AV_INFO_TIME

--- a/video.c
+++ b/video.c
@@ -278,8 +278,6 @@ static const VideoModule NoopModule;	///< forward definition of noop module
     /// selected video module
 static const VideoModule *VideoUsedModule = &NoopModule;
 
-signed char VideoHardwareDecoder = -1;	///< flag use hardware decoder
-
 static char VideoSurfaceModesChanged;	///< flag surface modes changed
 
 static uint32_t VideoBackground;	///< video background color
@@ -5769,13 +5767,6 @@ void VideoInit(const char *display_name)
     VideoUsedModule = &NoopModule;
 
   found:
-    // FIXME: make it configurable from gui
-    if (getenv("NO_MPEG_HW")) {
-	VideoHardwareDecoder = 1;
-    }
-    if (getenv("NO_HW")) {
-	VideoHardwareDecoder = 0;
-    }
     //xcb_prefetch_maximum_request_length(Connection);
     xcb_flush(Connection);
 

--- a/video.h
+++ b/video.h
@@ -61,9 +61,6 @@ extern void VideoSet60HzMode(int);
     /// Set soft start audio/video sync.
 extern void VideoSetSoftStartSync(int);
 
-    /// Set show black picture during channel switch.
-extern void VideoSetBlackPicture(int);
-
     /// Set brightness adjustment.
 extern void VideoSetBrightness(int);
 

--- a/video.h
+++ b/video.h
@@ -17,7 +17,6 @@ typedef struct __video_stream__ VideoStream;
 //  Variables
 //----------------------------------------------------------------------------
 
-extern signed char VideoHardwareDecoder;    ///< flag use hardware decoder
 extern char VideoIgnoreRepeatPict;	///< disable repeat pict warning
 extern int VideoAudioDelay;		///< audio/video delay
 extern char ConfigStartX11Server;	///< flag start the x11 server

--- a/video.h
+++ b/video.h
@@ -44,9 +44,6 @@ extern enum AVPixelFormat Video_get_format(VideoHwDecoder *, AVCodecContext *, c
     /// Render a ffmpeg frame.
 extern void VideoRenderFrame(VideoHwDecoder *, const AVCodecContext *, const AVFrame *);
 
-    /// Get hwaccel context for ffmpeg.
-extern void *VideoGetHwAccelContext(VideoHwDecoder *);
-
     /// Poll video events.
 extern void VideoPollEvent(void);
 

--- a/video.h
+++ b/video.h
@@ -161,9 +161,6 @@ extern void VideoOsdDrawARGB(int, int, int, int, int, const uint8_t *, int, int)
     /// Get OSD size.
 extern void VideoGetOsdSize(int *, int *);
 
-    /// Set OSD size.
-extern void VideoSetOsdSize(int, int);
-
     /// Set video clock.
 extern void VideoSetClock(VideoHwDecoder *, int64_t);
 


### PR DESCRIPTION
This PR changes a lot of logic in vaapidevice to utilize va-api decoding in ffmpeg. VPP functionalities such as post-processing or deinterlacing is still handled by plugin internal structures.

Also changed the logic of how surfaces are sized. This improves picture quality when doing 576i -> 1080p (or larger) scaling & deinterlacing

Also resolves #61 and resolves #63