### PR TITLE
System report

### DIFF
--- a/README
+++ b/README
@@ -37,6 +37,18 @@ Install:
 	You can edit Makefile to enable/disable Alsa support.
 	The default is to autodetect as much as possible.
 
+Issues/bugs:
+------------
+
+	If any issues or bugs arise, please, open an Github issue here:
+	https://github.com/pesintta/vdr-plugin-vaapidevice/issues
+
+	Remember to include your system report into the Github issue by
+	the included script:
+
+	export DISPLAY=:0.0
+	./generate_system_report.sh
+
 Setup:	environment
 ------
 	Following is supported:

--- a/generate_system_report.sh
+++ b/generate_system_report.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+check_component () {
+    BIN=$(command -v "${1}" 2>/dev/null)
+    echo "##### ${1}"
+    echo "\`\`\`"
+    if [ -n "${BIN}" ]; then
+        ${BIN} "${2}" 2>/dev/null
+    else
+        echo "The '${1}' command not found! Please, install!"
+    fi
+    echo "\`\`\`"
+}
+
+echo "#### VAAPIDEVICE SYSTEM INFORMATION REPORT"
+check_component "inxi" "-CGASMNzx -! 31"
+check_component "vainfo" ""
+check_component "ffmpeg" "-version"
+echo "##### INCLUDE THIS REPORT INTO YOUR GITHUB ISSUE"

--- a/generate_system_report.sh
+++ b/generate_system_report.sh
@@ -13,7 +13,9 @@ check_component () {
 }
 
 echo "#### VAAPIDEVICE SYSTEM INFORMATION REPORT"
-check_component "inxi" "-CGASMNzx -! 31"
+check_component "inxi" "-CGASMzx -! 31"
 check_component "vainfo" ""
-check_component "ffmpeg" "-version"
+check_component "ffmpeg" "-version" | sed '/^configuration:/d'
+check_component "gcc" "-dumpversion"
+check_component "svdrpsend" "plug vaapidevice dbug" | sed 's/^\(22[0-1]\) [a-zA-Z0-9]* \(.*\)$/\1 <filter> \2/'
 echo "##### INCLUDE THIS REPORT INTO YOUR GITHUB ISSUE"

--- a/vaapidevice.cpp
+++ b/vaapidevice.cpp
@@ -179,43 +179,54 @@ class cDebugStatistics:public cThread
     int area_h;
     int area_bpp;
 
+    cString VideoStats(void)
+    {
+	cString stats = "";
+	char *info = GetVideoStats();
+	if (info)
+	{
+	    stats = info;
+	    free(info);
+	}
+	return stats;
+    }
+
+    cString VideoInfo(void)
+    {
+	cString stats = "";
+	char *info = GetVideoInfo();
+
+	if (info) {
+	    stats = info;
+	    free(info);
+	}
+	return stats;
+    }
+
+    cString AudioInfo(void)
+    {
+	cString stats = "";
+	char *info = GetAudioInfo();
+
+	if (info) {
+	    stats = info;
+	    free(info);
+	}
+	return stats;
+    }
+
     void Draw(void)
     {
 	LOCK_THREAD;
-	if (osd)
-	{
+	if (osd) {
 	    const cFont *font = cFont::GetFont(fontSml);
 	    int y = 0, h = font->Height();
-	    char *info = GetVideoStats();
-	    if (info)
-	    {
-		osd->DrawText(0, y, info, clrWhite, clrGray50, font, 2160, h);
-		free(info);
-	    } else
-	    {
-		osd->DrawRectangle(0, y, 2160, y + h, clrGray50);
-	    }
+
+	    osd->DrawText(0, y, *VideoStats(), clrWhite, clrGray50, font, area_w, h);
 	    y += h;
-
-	    info = GetVideoInfo();
-
-	    if (info) {
-		osd->DrawText(0, y, info, clrWhite, clrGray50, font, 2160, h);
-		free(info);
-	    } else {
-		osd->DrawRectangle(0, y, 2160, y + h, clrGray50);
-	    }
+	    osd->DrawText(0, y, *VideoInfo(), clrWhite, clrGray50, font, area_w, h);
 	    y += h;
-
-	    info = GetAudioInfo();
-
-	    if (info) {
-		osd->DrawText(0, y, info, clrWhite, clrGray50, font, 2160, h);
-		free(info);
-	    } else {
-		osd->DrawRectangle(0, y, 2160, y + h, clrGray50);
-	    }
-
+	    osd->DrawText(0, y, *AudioInfo(), clrWhite, clrGray50, font, area_w, h);
 	    y += h;
 
 	    osd->Flush();
@@ -269,6 +280,11 @@ class cDebugStatistics:public cThread
 	}
 	Start();
 	return true;
+    }
+
+    cString Dump(void)
+    {
+	return cString::sprintf("%s\n%s\n%s\n", *VideoStats(), *VideoInfo(), *AudioInfo());
     }
 };
 
@@ -2480,7 +2496,8 @@ static const char *SVDRPHelpText[] = {
 	"    SUSPEND_NORMAL   ==  1  (911)\n" "	   SUSPEND_DETACHED ==	2  (912)\n",
     "RAIS\n" "\040	 Raise vaapidevice window\n\n" "	If Xserver is not started by vaapidevice, the window which\n"
 	"    contains the vaapidevice frontend will be raised to the front.\n",
-    "TRAC [ <mode> ]\n" "    gets and/or sets used tracing mode.\n",
+    "TRAC [ <mode> ]\n" "    Get and/or set used tracing mode.\n",
+    "DBUG\n" "\040	 Show debug information.\n",
     NULL
 };
 
@@ -2660,6 +2677,9 @@ cString cPluginVaapiDevice::SVDRPCommand(const char *command, const char *option
 	if (option && *option)
 	    TraceMode = strtol(option, NULL, 0) & 0xFFFF;
 	return cString::sprintf("tracing mode: 0x%04X\n", TraceMode);
+    }
+    if (!strcasecmp(command, "DBUG")) {
+	return MyDebug->Dump();
     }
 
     return NULL;


### PR DESCRIPTION
#### VAAPIDEVICE SYSTEM INFORMATION REPORT
##### inxi
```
System:    Kernel: 4.15.8-gentoo x86_64 bits: 64 gcc: 6.4.0 Console: tty 2
           Distro: Gentoo Base System release 2.4.1
Machine:   Device: desktop Mobo: Intel model: D54250WYK v: H13922-303 serial: N/A
           BIOS: Intel v: WYLPT10H.86A.0045.2017.0302.2108 date: 03/02/2017
CPU:       Dual core Intel Core i5-4250U (-MT-MCP-)
           arch: Haswell rev.1 cache: 3072 KB
           flags: (lm nx sse sse2 sse3 sse4_1 sse4_2 ssse3 vmx) bmips: 7582
           clock speeds: max: 2600 MHz 1: 912 MHz 2: 1375 MHz 3: 1381 MHz
           4: 1460 MHz
Graphics:  Card: Intel Haswell-ULT Integrated Graphics Controller
           bus-ID: 00:02.0
           Display Server: X.org 1.19.5 driver: intel
           tty size: 211x52 Advanced Data: N/A out of X
Audio:     Card Intel Haswell-ULT HD Audio Controller
           driver: snd_hda_intel bus-ID: 00:03.0
           Sound: Advanced Linux Sound Architecture v: k4.15.8-gentoo
```
##### vainfo
```
vainfo: VA-API version: 1.1 (libva 2.1.0)
vainfo: Driver version: Intel i965 driver for Intel(R) Haswell Mobile - 2.1.0
vainfo: Supported profile and entrypoints
      VAProfileMPEG2Simple            : VAEntrypointVLD
      VAProfileMPEG2Simple            : VAEntrypointEncSlice
      VAProfileMPEG2Main              : VAEntrypointVLD
      VAProfileMPEG2Main              : VAEntrypointEncSlice
      VAProfileH264ConstrainedBaseline: VAEntrypointVLD
      VAProfileH264ConstrainedBaseline: VAEntrypointEncSlice
      VAProfileH264Main               : VAEntrypointVLD
      VAProfileH264Main               : VAEntrypointEncSlice
      VAProfileH264High               : VAEntrypointVLD
      VAProfileH264High               : VAEntrypointEncSlice
      VAProfileH264MultiviewHigh      : VAEntrypointVLD
      VAProfileH264MultiviewHigh      : VAEntrypointEncSlice
      VAProfileH264StereoHigh         : VAEntrypointVLD
      VAProfileH264StereoHigh         : VAEntrypointEncSlice
      VAProfileVC1Simple              : VAEntrypointVLD
      VAProfileVC1Main                : VAEntrypointVLD
      VAProfileVC1Advanced            : VAEntrypointVLD
      VAProfileNone                   : VAEntrypointVideoProc
      VAProfileJPEGBaseline           : VAEntrypointVLD
```
##### ffmpeg
```
ffmpeg version 3.3.6 Copyright (c) 2000-2017 the FFmpeg developers
built with gcc 6.4.0 (Gentoo 6.4.0 p1.1)
libavutil      55. 58.100 / 55. 58.100
libavcodec     57. 89.100 / 57. 89.100
libavformat    57. 71.100 / 57. 71.100
libavdevice    57.  6.100 / 57.  6.100
libavfilter     6. 82.100 /  6. 82.100
libavresample   3.  5.  0 /  3.  5.  0
libswscale      4.  6.100 /  4.  6.100
libswresample   2.  7.100 /  2.  7.100
libpostproc    54.  5.100 / 54.  5.100
```
##### gcc
```
6.4.0
```
##### svdrpsend
```
220 <filter> SVDRP VideoDiskRecorder 2.3.8; Sun Mar 11 12:41:34 2018; UTF-8
900- Frames: missed(0) duped(124816) dropped(0) total(111856) PTS( 3:13:39.018) drift(91) audio(245) video(0)
900- Video: mpeg2video/vaapi_vld 720x576i 16:9 @ 1920x1080 - Intel i965 driver for Intel(R) Haswell Mobile - 2.1.0
900  Audio: mp2 48000Hz 2 channels
221 <filter> closing connection
```
##### INCLUDE THIS REPORT INTO YOUR GITHUB ISSUE
