### PR TITLE
Enhance DBUG command

### DIFF
--- a/vaapidevice.cpp
+++ b/vaapidevice.cpp
@@ -125,6 +125,7 @@ static volatile int DoMakePrimary;	///< switch primary device to this
 #define SUSPEND_DETACHED	2	    ///< detached suspend mode
 static signed char SuspendMode;		///< suspend mode
 volatile char SoftIsPlayingVideo;	///< stream contains video data
+static cString CommandLineParameters = "";  ///< plugin's command-line parameters
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -284,7 +285,8 @@ class cDebugStatistics:public cThread
 
     cString Dump(void)
     {
-	return cString::sprintf("%s\n%s\n%s\n", *VideoStats(), *VideoInfo(), *AudioInfo());
+	return cString::sprintf("%s\n%s\n%s\nCommand:%s\n", *VideoStats(), *VideoInfo(), *AudioInfo(),
+	    *CommandLineParameters);
     }
 };
 
@@ -2140,6 +2142,9 @@ const char *cPluginVaapiDevice::CommandLineHelp(void)
 */
 bool cPluginVaapiDevice::ProcessArgs(int argc, char *argv[])
 {
+    for (int i = 0; i < argc; ++i) {
+	CommandLineParameters = *cString::sprintf("%s %s", *CommandLineParameters, argv[i]);
+    }
     return::ProcessArgs(argc, argv);
 }
 


### PR DESCRIPTION
#### VAAPIDEVICE SYSTEM INFORMATION REPORT
##### inxi
```
System:    Kernel: 4.15.8-gentoo x86_64 bits: 64 gcc: 6.4.0 Console: tty 0
           Distro: Gentoo Base System release 2.4.1
Machine:   Device: desktop Mobo: Intel model: D54250WYK v: H13922-303 serial: N/A
           BIOS: Intel v: WYLPT10H.86A.0045.2017.0302.2108 date: 03/02/2017
CPU:       Dual core Intel Core i5-4250U (-MT-MCP-)
           arch: Haswell rev.1 cache: 3072 KB
           flags: (lm nx sse sse2 sse3 sse4_1 sse4_2 ssse3 vmx) bmips: 7582
           clock speeds: max: 2600 MHz 1: 1003 MHz 2: 1214 MHz 3: 1159 MHz
           4: 989 MHz
Graphics:  Card: Intel Haswell-ULT Integrated Graphics Controller
           bus-ID: 00:02.0
           Display Server: X.org 1.19.5 driver: intel
           tty size: 211x52 Advanced Data: N/A out of X
Audio:     Card Intel Haswell-ULT HD Audio Controller
           driver: snd_hda_intel bus-ID: 00:03.0
           Sound: Advanced Linux Sound Architecture v: k4.15.8-gentoo
```
##### vainfo
```
vainfo: VA-API version: 1.1 (libva 2.1.0)
vainfo: Driver version: Intel i965 driver for Intel(R) Haswell Mobile - 2.1.0
vainfo: Supported profile and entrypoints
      VAProfileMPEG2Simple            : VAEntrypointVLD
      VAProfileMPEG2Simple            : VAEntrypointEncSlice
      VAProfileMPEG2Main              : VAEntrypointVLD
      VAProfileMPEG2Main              : VAEntrypointEncSlice
      VAProfileH264ConstrainedBaseline: VAEntrypointVLD
      VAProfileH264ConstrainedBaseline: VAEntrypointEncSlice
      VAProfileH264Main               : VAEntrypointVLD
      VAProfileH264Main               : VAEntrypointEncSlice
      VAProfileH264High               : VAEntrypointVLD
      VAProfileH264High               : VAEntrypointEncSlice
      VAProfileH264MultiviewHigh      : VAEntrypointVLD
      VAProfileH264MultiviewHigh      : VAEntrypointEncSlice
      VAProfileH264StereoHigh         : VAEntrypointVLD
      VAProfileH264StereoHigh         : VAEntrypointEncSlice
      VAProfileVC1Simple              : VAEntrypointVLD
      VAProfileVC1Main                : VAEntrypointVLD
      VAProfileVC1Advanced            : VAEntrypointVLD
      VAProfileNone                   : VAEntrypointVideoProc
      VAProfileJPEGBaseline           : VAEntrypointVLD
```
##### ffmpeg
```
ffmpeg version 3.3.6 Copyright (c) 2000-2017 the FFmpeg developers
built with gcc 6.4.0 (Gentoo 6.4.0 p1.1)
libavutil      55. 58.100 / 55. 58.100
libavcodec     57. 89.100 / 57. 89.100
libavformat    57. 71.100 / 57. 71.100
libavdevice    57.  6.100 / 57.  6.100
libavfilter     6. 82.100 /  6. 82.100
libavresample   3.  5.  0 /  3.  5.  0
libswscale      4.  6.100 /  4.  6.100
libswresample   2.  7.100 /  2.  7.100
libpostproc    54.  5.100 / 54.  5.100
```
##### gcc
```
6.4.0
```
##### svdrpsend
```
220 <filter> SVDRP VideoDiskRecorder 2.3.8; Sun Mar 11 17:15:46 2018; UTF-8
900- Frames: missed(0) duped(1233) dropped(0) total(1200) PTS(16:09:17.909) drift(148) audio(377) video(0)
900- Video: mpeg2video/vaapi_vld 720x576i 16:9 @ 1920x1080 - Intel i965 driver for Intel(R) Haswell Mobile - 2.1.0
900- Audio: mp2 48000Hz 2 channels
900 Command: vaapidevice -a hw:0,3 -d :0.0 -f
221 <filter> closing connection
```
##### INCLUDE THIS REPORT INTO YOUR GITHUB ISSUE
