### PR TITLE
Show filters on debug OSD

### DIFF
--- a/vaapidev.c
+++ b/vaapidev.c
@@ -3040,6 +3040,14 @@ char *GetVideoStats(void)
 }
 
 /*
+**	Get video decoder filters.
+*/
+char *GetVideoFilters(void)
+{
+    return MyVideoStream->HwDecoder ? VideoGetFilters(MyVideoStream->HwDecoder) : NULL;
+}
+
+/*
 **	Get video decoder info.
 **
 */

--- a/vaapidevice.cpp
+++ b/vaapidevice.cpp
@@ -193,6 +193,18 @@ class cDebugStatistics:public cThread
 	return stats;
     }
 
+    cString VideoFilters(void)
+    {
+	cString stats = "";
+	char *info = GetVideoFilters();
+
+	if (info) {
+	    stats = info;
+	    free(info);
+	}
+	return stats;
+    }
+
     cString VideoInfo(void)
     {
 	cString stats = "";
@@ -225,6 +237,8 @@ class cDebugStatistics:public cThread
 	    int y = 0, h = font->Height();
 
 	    osd->DrawText(0, y, *VideoStats(), clrWhite, clrGray50, font, area_w, h);
+	    y += h;
+	    osd->DrawText(0, y, *VideoFilters(), clrWhite, clrGray50, font, area_w, h);
 	    y += h;
 	    osd->DrawText(0, y, *VideoInfo(), clrWhite, clrGray50, font, area_w, h);
 	    y += h;
@@ -286,8 +300,8 @@ class cDebugStatistics:public cThread
 
     cString Dump(void)
     {
-	return cString::sprintf("%s\n%s\n%s\nCommand:%s\n", *VideoStats(), *VideoInfo(), *AudioInfo(),
-	    *CommandLineParameters);
+	return cString::sprintf("%s\n%s\n%s\n%s\nCommand:%s\n", *VideoStats(), *VideoFilters(), *VideoInfo(),
+	    *AudioInfo(), *CommandLineParameters);
     }
 };
 

--- a/vaapidevice.h
+++ b/vaapidevice.h
@@ -83,6 +83,8 @@ extern "C"
 
     /// Get video decoder statistics
     extern char *GetVideoStats(void);
+    /// Get video decoder filters
+    extern char *GetVideoFilters(void);
     /// Get video decoder info
     extern char *GetVideoInfo(void);
     /// Get audio decoder info

--- a/video.c
+++ b/video.c
@@ -3268,13 +3268,11 @@ static void VaapiBlackSurface(VaapiDecoder * decoder)
 static int VaapiIsPictureChanged(VaapiDecoder * decoder, const AVCodecContext * video_ctx, const AVFrame * frame)
 {
     if (video_ctx->width != decoder->InputWidth || video_ctx->height != decoder->InputHeight
-	|| video_ctx->pix_fmt != decoder->PixFmt) {
-	Debug7("video/vaapi: Picture change detected");
-	return 1;
-    }
-
-    if (frame->interlaced_frame != decoder->Interlaced) {
-	Debug7("video/vaapi: Interlacing change detected");
+	|| video_ctx->pix_fmt != decoder->PixFmt || frame->interlaced_frame != decoder->Interlaced) {
+	Debug7("video/vaapi: Picture change detected: %dx%d%s (%s) -> %dx%d%s (%s)", decoder->InputWidth,
+	    decoder->InputHeight, decoder->Interlaced ? "i" : "p", av_get_pix_fmt_name(decoder->PixFmt),
+	    video_ctx->width, video_ctx->height, frame->interlaced_frame ? "i" : "p",
+	    av_get_pix_fmt_name(video_ctx->pix_fmt));
 	return 1;
     }
 

--- a/video.h
+++ b/video.h
@@ -178,6 +178,9 @@ extern uint8_t *VideoGrab(int *, int *, int *, int);
     /// Get decoder statistics.
 extern char *VideoGetStats(VideoHwDecoder *);
 
+    /// Get decoder filters.
+extern char *VideoGetFilters(VideoHwDecoder *);
+
     /// Get video info
 extern char *VideoGetInfo(VideoHwDecoder *, const char *);
 


### PR DESCRIPTION
```
220 <filter> SVDRP VideoDiskRecorder 2.3.8; Thu Mar 15 21:56:57 2018; UTF-8
900- Frames: missed(0) duped(44226) dropped(0) total(44198) PTS(24:02:03.409) drift(140) audio(270) video(0)
900- Filters: denoise >> deinterlace >> color balance >> skin tone
900- Video: mpeg2video/vaapi_vld 720x576i 16:9 @ 1920x1080 - Intel i965 driver for Intel(R) Haswell Mobile - 2.1.0
900- Audio: mp2 48000Hz 2 channels
900 Command: vaapidevice -a hw:0,3 -d :0.0 -f -v va-api
221 <filter> closing connection
```
